### PR TITLE
Option to detect host VirtualBox version to match GuestAdditions installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for virtualbox-guest
-virtualbox_version: 5.0.26
+virtualbox_version: auto

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 # tasks file for virtualbox-guest
 
+- block:
+  - name: If virtualbox_version is set to auto then determine the host version
+    local_action: shell vboxmanage --version | awk -F r '{print $1}'
+    register: host_vbox_version
+
+  - name: Override virtualbox_version if defaults set to auto
+    set_fact: virtualbox_version="{{ host_vbox_version.stdout }}"
+
+  when: virtualbox_version == "auto"
+
 - name: Determine if (the requested version of) vboxguestadditions is installed
   shell: modinfo vboxguest 2>/dev/null|awk '/^version/{print $2}'
   register: vbox_guest_version


### PR DESCRIPTION
I added an option to the `virtualbox_version` variable, when set to `auto` it will detect the host's VirtualBox version and install the matching version of GuestAdditions. I decided to use a block for this change for logical grouping. I believe it would break backward compatibility since this feature was introduced in 2.0.
