### PR TITLE
Allow unprivileged execution & register host_vbox_version correctly

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,9 @@
 
 - block:
   - name: If virtualbox_version is set to auto then determine the host version
-    local_action: shell vboxmanage --version | awk -F'[r_]' '{print $1}' 
+    local_action: shell vboxmanage --version | awk -F'[r_]' '{print $1}'
+    register: host_vbox_version
+    become: no
 
   - name: Check if virtualbox_version could be determined
     fail: msg="Could not determine virtualbox_version - please specify this variable"


### PR DESCRIPTION
Hi Peter,

Thanks for the handy playbook. I noticed that if the local_action to register the virtualbox version is run with "become: no" we don't need to provide privileges to our local host. In addition to this, it seems like the variable registration was missing.

Thanks.