### PR TITLE
yum: do not use unsupported parameter warn

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,7 +142,6 @@
               ["kernel", "kernel-headers-{{ kernel.stdout }}", "kernel-devel"]
             state: latest  # needed latest for dmks to find matching header
             update_cache: yes
-            warn: no
           when: kernel is defined and kernel.stdout is defined
 
       when: ansible_os_family == "RedHat"


### PR DESCRIPTION
The latest Ansible release appears to stop when encountering unsupported parameters.

```bash
    vagrant: TASK [PeterMosmans.virtualbox-guest : Install latest kernel and headers for CentOSes] ***
    vagrant: fatal: [default]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (dnf) module: warn Supported parameters include: allow_downgrade, autoremove, bugfix, conf_file, disable_excludes, disable_gpg_check, disable_plugin, disablerepo, download_dir, download_only, enable_plugin, enablerepo, exclude, install_repoquery, install_weak_deps, installroot, list, lock_timeout, name, releasever, security, skip_broken, state, update_cache, update_only, validate_certs"}
    vagrant:

```