### PR TITLE
RedHat family: add elfutils-libelf-devel dependency

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,7 +139,7 @@
         - name: Install latest kernel and headers for CentOSes
           yum:
             name:
-              ["kernel", "kernel-headers-{{ kernel.stdout }}", "kernel-devel"]
+              ["kernel", "kernel-headers-{{ kernel.stdout }}", "kernel-devel", "elfutils-libelf-devel"]
             state: latest  # needed latest for dmks to find matching header
             update_cache: yes
           when: kernel is defined and kernel.stdout is defined


### PR DESCRIPTION
Starting with CentOS 8, elfutils-libelf-devel is no longer a dependency of dkms, which causes the guest additions build to fail.