### PR TITLE
Fix vbox guest upgrade

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,7 +148,7 @@
 
     - name: Install necessary packages for compiling
       package:
-        name: ["bzip2", "dkms", "gcc", "make"]
+        name: ["bzip2", "dkms", "gcc", "make", "perl"]
         # update_cache=yes
         # install-recommends=no
         state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -153,6 +153,11 @@
         # install-recommends=no
         state: present
 
+    - name: Uninstall previous VBoxGuestAdditions
+      shell: echo "yes" | /media/cdrom/VBoxLinuxAdditions.run uninstall
+      when: vbox_guest_version.stdout is defined 
+      ignore_errors: yes
+
     - name: Build and install x11 VBoxGuestAdditions from file
       shell: /media/cdrom/VBoxLinuxAdditions.run
       when: virtualbox_x11 is defined and virtualbox_x11

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -141,7 +141,7 @@
 
     - name: Install necessary packages for compiling
       package:
-        name: ["bzip2", "dkms", "gcc", "make", "perl"]
+        name: ["bzip2", "dkms", "gcc", "make"]
         # update_cache=yes
         # install-recommends=no
         state: present


### PR DESCRIPTION
Turns out installation is pending when vbox is already installed
in guest. To fix that, we uninstall the current version and we
install correct vbox guest version.